### PR TITLE
Fix XML parsing, add a basic CLI and resolve a number of minor code quality, best practice and style issues

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -367,10 +367,12 @@ def save(licenses, base_uri, dir=os.curdir):
         f.write('\n')
 
 
-if __name__ == '__main__':
+def main(sys_argv=None):
+    if sys_argv is None:
+        sys_argv = sys.argv
     dir = os.curdir
-    if len(sys.argv) > 1:
-        dir = sys.argv[1]
+    if sys_argv and len(sys_argv) > 1:
+        dir = sys_argv[1]
     tree = get(uri=URI)
     root = tree.getroot()
     licenses = extract(root=root, base_uri=URI)
@@ -380,3 +382,7 @@ if __name__ == '__main__':
         raise ValueError('unused IDENTIFIERS keys: {}'.format(
             ', '.join(sorted(unused_identifiers))))
     save(licenses=licenses, base_uri='https://wking.github.io/fsf-api/', dir=dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/pull.py
+++ b/pull.py
@@ -317,7 +317,9 @@ def save(licenses, base_uri, dir=os.curdir):
             },
         },
     }
-    with open(os.path.join(schema_dir, 'license.jsonld'), 'w') as f:
+    with open(
+        os.path.join(schema_dir, 'license.jsonld'), 'w', encoding='utf-8'
+    ) as f:
         json.dump(obj=license_schema, fp=f, indent=2, sort_keys=True)
         f.write('\n')
     license_schema_uri = urllib.parse.urljoin(
@@ -328,13 +330,17 @@ def save(licenses, base_uri, dir=os.curdir):
         '@id': license_schema_uri,
     }
     licenses_schema.update(license_schema)
-    with open(os.path.join(schema_dir, 'licenses.jsonld'), 'w') as f:
+    with open(
+        os.path.join(schema_dir, 'licenses.jsonld'), 'w', encoding='utf-8'
+    ) as f:
         json.dump(obj=licenses_schema, fp=f, indent=2, sort_keys=True)
         f.write('\n')
     licenses_schema_uri = urllib.parse.urljoin(
         base=base_uri, url='schema/licenses.jsonld')
     index = sorted(licenses.keys())
-    with open(os.path.join(dir, 'licenses.json'), 'w') as f:
+    with open(
+        os.path.join(dir, 'licenses.json'), 'w', encoding='utf-8'
+    ) as f:
         json.dump(obj=index, fp=f, indent=2, sort_keys=True)
         f.write('\n')
     full_index = {
@@ -350,7 +356,7 @@ def save(licenses, base_uri, dir=os.curdir):
         license['@context'] = urllib.parse.urljoin(
             base=base_uri, url='schema/license.jsonld')
         license_path = os.path.join(dir, '{}.json'.format(id))
-        with open(license_path, 'w') as f:
+        with open(license_path, 'w', encoding='utf-8') as f:
             json.dump(obj=license, fp=f, indent=2, sort_keys=True)
             f.write('\n')
         for scheme, identifiers in license.get('identifiers', {}).items():
@@ -361,7 +367,9 @@ def save(licenses, base_uri, dir=os.curdir):
             for identifier in identifiers:
                 id_path = os.path.join(scheme_dir, '{}.json'.format(identifier))
                 os.link(license_path, id_path)
-    with open(os.path.join(dir, 'licenses-full.json'), 'w') as f:
+    with open(
+        os.path.join(dir, 'licenses-full.json'), 'w', encoding='utf-8'
+    ) as f:
         json.dump(obj=full_index, fp=f, indent=2, sort_keys=True)
         f.write('\n')
 

--- a/pull.py
+++ b/pull.py
@@ -243,9 +243,10 @@ def extract(root, base_uri=None):
     for dl in root.iter(tag='{http://www.w3.org/1999/xhtml}dl'):
         try:
             tags = TAGS[dl.attrib.get('class')]
-        except KeyError:
+        except KeyError as error:
             raise ValueError(
-                'unrecognized class {!r}'.format(dl.attrib.get('class')))
+                'unrecognized class {!r}'.format(dl.attrib.get('class'))
+            ) from error
         for a in dl.iter(tag='{http://www.w3.org/1999/xhtml}a'):
             if 'id' not in a.attrib:
                 continue
@@ -376,8 +377,7 @@ def main(sys_argv=None):
     tree = get(uri=URI)
     root = tree.getroot()
     licenses = extract(root=root, base_uri=URI)
-    unused_identifiers = {
-        key for key in IDENTIFIERS.keys() if key not in licenses}
+    unused_identifiers = {key for key in IDENTIFIERS if key not in licenses}
     if unused_identifiers:
         raise ValueError('unused IDENTIFIERS keys: {}'.format(
             ', '.join(sorted(unused_identifiers))))

--- a/pull.py
+++ b/pull.py
@@ -5,7 +5,6 @@
 import glob
 import html
 import io
-import itertools
 import json
 import os
 import re
@@ -260,7 +259,7 @@ def extract(root, base_uri=None):
                     license['name'] = a.text.strip()
                 else:
                     continue
-                uris = ['{}#{}'.format(base_uri, oid)]
+                uris = [f'{base_uri}#{oid}']
                 uri = a.attrib.get('href')
                 if uri:
                     if base_uri:
@@ -286,13 +285,7 @@ def extract(root, base_uri=None):
 def save(licenses, base_uri, dir=os.curdir):
     schema_dir = os.path.join(dir, 'schema')
     os.makedirs(schema_dir, exist_ok=True)
-    if sys.version_info >= (3, 5):
-        paths = glob.glob(os.path.join(dir, '**', '*.json'), recursive=True)
-    else:
-        paths = itertools.chain(
-            glob.glob(os.path.join(dir, '*.json')),
-            glob.glob(os.path.join(dir, '*', '*.json')),
-        )
+    paths = glob.glob(os.path.join(dir, '**', '*.json'), recursive=True)
     for path in paths:
         os.remove(path)
     license_schema = {
@@ -355,7 +348,7 @@ def save(licenses, base_uri, dir=os.curdir):
         full_index['licenses'][id] = license.copy()
         license['@context'] = urllib.parse.urljoin(
             base=base_uri, url='schema/license.jsonld')
-        license_path = os.path.join(dir, '{}.json'.format(id))
+        license_path = os.path.join(dir, f'{id}.json')
         with open(license_path, 'w', encoding='utf-8') as f:
             json.dump(obj=license, fp=f, indent=2, sort_keys=True)
             f.write('\n')
@@ -365,7 +358,7 @@ def save(licenses, base_uri, dir=os.curdir):
             if isinstance(identifiers, str):
                 identifiers = [identifiers]
             for identifier in identifiers:
-                id_path = os.path.join(scheme_dir, '{}.json'.format(identifier))
+                id_path = os.path.join(scheme_dir, f'{identifier}.json')
                 os.link(license_path, id_path)
     with open(
         os.path.join(dir, 'licenses-full.json'), 'w', encoding='utf-8'

--- a/pull.py
+++ b/pull.py
@@ -26,21 +26,21 @@ TAGS = {
 }
 
 SPLITS = {
-    'AcademicFreeLicense': [ # all versions through 3.0
+    'AcademicFreeLicense': [  # all versions through 3.0
         'AcademicFreeLicense1.1',
         'AcademicFreeLicense1.2',
         'AcademicFreeLicense2.0',
         'AcademicFreeLicense2.1',
         'AcademicFreeLicense3.0',
     ],
-    'CC-BY-NC': [ # any version (!)
+    'CC-BY-NC': [  # any version (!)
         'CC-BY-NC-1.0',
         'CC-BY-NC-2.0',
         'CC-BY-NC-2.5',
         'CC-BY-NC-3.0',
         'CC-BY-NC-4.0',
     ],
-    'CC-BY-ND': [ # any version
+    'CC-BY-ND': [  # any version
         'CC-BY-ND-1.0',
         'CC-BY-ND-2.0',
         'CC-BY-ND-2.5',
@@ -53,33 +53,33 @@ SPLITS = {
         'FDLv1.2',
         'FDLv1.3',
     ],
-    'FDLOther': [ # unify with FDL (multi-tag)
+    'FDLOther': [  # unify with FDL (multi-tag)
         'FDLv1.1',
         'FDLv1.2',
         'FDLv1.3',
     ],
-    'FreeBSDDL': ['FreeBSD'], # unify (multi-tag)
-    'NPL': [ # versions 1.0 and 1.1
+    'FreeBSDDL': ['FreeBSD'],  # unify (multi-tag)
+    'NPL': [  # versions 1.0 and 1.1
         'NPL-1.0',
         'NPL-1.1',
     ],
-    'OSL': [ # any version through 3.0
+    'OSL': [  # any version through 3.0
         'OSL-1.0',
         'OSL-1.1',
         'OSL-2.0',
         'OSL-2.1',
         'OSL-3.0',
     ],
-    'PythonOld': [ # 1.6b1 through 2.0 and 2.1
+    'PythonOld': [  # 1.6b1 through 2.0 and 2.1
         'Python1.6b1',
         'Python2.0',
         'Python2.1',
     ],
-    'SILOFL': [ # title has 1.1 but text says the same metadata applies to 1.0
+    'SILOFL': [  # title has 1.1 but text says the same metadata applies to 1.0
         'SILOFL-1.0',
         'SILOFL-1.1',
     ],
-    'Zope2.0': [ # versions 2.0 and 2.1
+    'Zope2.0': [  # versions 2.0 and 2.1
         'Zope2.0',
         'Zope2.1',
     ],
@@ -152,9 +152,13 @@ IDENTIFIERS = {
     'FreeBSD': {'spdx': ['BSD-2-Clause-FreeBSD']},
     'freetype': {'spdx': ['FTL']},
     'GNUAllPermissive': {'spdx': ['FSFAP']},
-    'GNUGPLv3': {'spdx': ['GPL-3.0-or-later', 'GPL-3.0-only', 'GPL-3.0', 'GPL-3.0+']},
+    'GNUGPLv3': {
+        'spdx': ['GPL-3.0-or-later', 'GPL-3.0-only', 'GPL-3.0', 'GPL-3.0+']
+    },
     'gnuplot': {'spdx': ['gnuplot']},
-    'GPLv2': {'spdx': ['GPL-2.0-or-later', 'GPL-2.0-only', 'GPL-2.0', 'GPL-2.0+']},
+    'GPLv2': {
+        'spdx': ['GPL-2.0-or-later', 'GPL-2.0-only', 'GPL-2.0', 'GPL-2.0+']
+    },
     'HPND': {'spdx': ['HPND']},
     'IBMPL': {'spdx': ['IPL-1.0']},
     'iMatix': {'spdx': ['iMatix']},
@@ -164,8 +168,12 @@ IDENTIFIERS = {
     'IPAFONT': {'spdx': ['IPA']},
     'ISC': {'spdx': ['ISC']},
     'JSON': {'spdx': ['JSON']},
-    'LGPLv3': {'spdx': ['LGPL-3.0-or-later', 'LGPL-3.0-only', 'LGPL-3.0', 'LGPL-3.0+']},
-    'LGPLv2.1': {'spdx': ['LGPL-2.1-or-later', 'LGPL-2.1-only', 'LGPL-2.1', 'LGPL-2.1+']},
+    'LGPLv3': {
+        'spdx': ['LGPL-3.0-or-later', 'LGPL-3.0-only', 'LGPL-3.0', 'LGPL-3.0+']
+    },
+    'LGPLv2.1': {
+        'spdx': ['LGPL-2.1-or-later', 'LGPL-2.1-only', 'LGPL-2.1', 'LGPL-2.1+']
+    },
     'LPPL-1.2': {'spdx': ['LPPL-1.2']},
     'LPPL-1.3a': {'spdx': ['LPPL-1.3a']},
     'lucent102': {'spdx': ['LPL-1.02']},
@@ -222,7 +230,8 @@ IDENTIFIERS = {
 
 def convert_html_escapes_to_xml(html_text):
     html_entities = set(
-        re.findall(r'&(?!quot|lt|gt|amp|apos)[a-zA-Z]{1,30};', html_text))
+        re.findall(r'&(?!quot|lt|gt|amp|apos)[a-zA-Z]{1,30};', html_text)
+    )
     for entity in html_entities:
         html_text = html_text.replace(entity, html.unescape(entity))
     return html_text
@@ -264,7 +273,9 @@ def extract(root, base_uri=None):
                 uri = a.attrib.get('href')
                 if uri:
                     if base_uri:
-                        uris.append(urllib.parse.urljoin(base=base_uri, url=uri))
+                        uris.append(
+                            urllib.parse.urljoin(base=base_uri, url=uri)
+                        )
                 license_data['uris'] = uris
                 identifiers = IDENTIFIERS.get(license_id)
                 if identifiers:
@@ -278,8 +289,9 @@ def extract(root, base_uri=None):
                             licenses[license_id]['uris'].append(uri)
     unused_splits = set(SPLITS.keys()).difference(oids)
     if unused_splits:
-        raise ValueError('unused SPLITS keys: {}'.format(
-            ', '.join(sorted(unused_splits))))
+        raise ValueError(
+            'unused SPLITS keys: {}'.format(', '.join(sorted(unused_splits)))
+        )
     return licenses
 
 
@@ -292,9 +304,7 @@ def save(licenses, base_uri, output_dir=os.curdir):
     license_schema = {
         '@context': {
             'schema': 'https://schema.org/',
-            'id': {
-                '@id': 'schema:identifier'
-            },
+            'id': {'@id': 'schema:identifier'},
             'name': {
                 '@id': 'schema:name',
             },
@@ -317,7 +327,8 @@ def save(licenses, base_uri, output_dir=os.curdir):
         json.dump(obj=license_schema, fp=f, indent=2, sort_keys=True)
         f.write('\n')
     license_schema_uri = urllib.parse.urljoin(
-        base=base_uri, url='schema/license.jsonld')
+        base=base_uri, url='schema/license.jsonld'
+    )
     licenses_schema = license_schema.copy()
     licenses_schema['@context']['licenses'] = {
         '@container': '@index',
@@ -330,7 +341,8 @@ def save(licenses, base_uri, output_dir=os.curdir):
         json.dump(obj=licenses_schema, fp=f, indent=2, sort_keys=True)
         f.write('\n')
     licenses_schema_uri = urllib.parse.urljoin(
-        base=base_uri, url='schema/licenses.jsonld')
+        base=base_uri, url='schema/licenses.jsonld'
+    )
     index = sorted(licenses.keys())
     with open(
         os.path.join(output_dir, 'licenses.json'), 'w', encoding='utf-8'
@@ -348,7 +360,8 @@ def save(licenses, base_uri, output_dir=os.curdir):
         license_data['id'] = license_id
         full_index['licenses'][license_id] = license_data.copy()
         license_data['@context'] = urllib.parse.urljoin(
-            base=base_uri, url='schema/license.jsonld')
+            base=base_uri, url='schema/license.jsonld'
+        )
         license_path = os.path.join(output_dir, f'{license_id}.json')
         with open(license_path, 'w', encoding='utf-8') as f:
             json.dump(obj=license_data, fp=f, indent=2, sort_keys=True)
@@ -379,8 +392,11 @@ def main(sys_argv=None):
     licenses = extract(root=root, base_uri=URI)
     unused_identifiers = {key for key in IDENTIFIERS if key not in licenses}
     if unused_identifiers:
-        raise ValueError('unused IDENTIFIERS keys: {}'.format(
-            ', '.join(sorted(unused_identifiers))))
+        raise ValueError(
+            'unused IDENTIFIERS keys: {}'.format(
+                ', '.join(sorted(unused_identifiers))
+            )
+        )
     save(
         licenses=licenses,
         base_uri='https://wking.github.io/fsf-api/',

--- a/pull.py
+++ b/pull.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""Generate the FSF license API JSON data from the FSF license list page."""
+
 import glob
 import html
 import io
@@ -229,6 +231,7 @@ IDENTIFIERS = {
 
 
 def convert_html_escapes_to_xml(html_text):
+    """Avoid XML parsing errors by converting HTML escape codes to XML."""
     html_entities = set(
         re.findall(r'&(?!quot|lt|gt|amp|apos)[a-zA-Z]{1,30};', html_text)
     )
@@ -238,6 +241,7 @@ def convert_html_escapes_to_xml(html_text):
 
 
 def get(uri):
+    """Get the license list page data from the FSF web site."""
     parser = lxml.etree.XMLParser(ns_clean=True, resolve_entities=False)
     with urllib.request.urlopen(uri) as response:
         response_data = response.read().decode()
@@ -247,6 +251,7 @@ def get(uri):
 
 
 def extract(root, base_uri=None):
+    """Parse the license list page and extract the needed license data."""
     oids = set()
     licenses = {}
     for dl in root.iter(tag='{http://www.w3.org/1999/xhtml}dl'):
@@ -296,6 +301,7 @@ def extract(root, base_uri=None):
 
 
 def save(licenses, base_uri, output_dir=os.curdir):
+    """Save the license data to a files in the appropriate JSON schema."""
     schema_dir = os.path.join(output_dir, 'schema')
     os.makedirs(schema_dir, exist_ok=True)
     paths = glob.glob(os.path.join(output_dir, '**', '*.json'), recursive=True)
@@ -382,6 +388,7 @@ def save(licenses, base_uri, output_dir=os.curdir):
 
 
 def main(sys_argv=None):
+    """Load the license list page, parse it and generate the API output."""
     if sys_argv is None:
         sys_argv = sys.argv
     output_dir = os.curdir


### PR DESCRIPTION
* [x] Add hacks and fixes for the XML parsing, which was broken due to dependencies issues and changes on the source page
* [x] Add a basic CLI with help and usage info and better argument handling
* [x] Add `source-uri` and `api-base-uri` args in the Python and CLI APIs to allow reading different sources and deploying to different targets
* [x] Add explicit encoding argument to open(), to avoid falling back to the platform dependent default instead of UTF-8
* [x] Avoid shadowing builtins, which can lead to bugs and developer/tool confusion
* [x] Remove old workarounds for Py3.5 and upgrade syntax to use format strings
* [x] Factor the top-level CLI code into a main() function, and the actual business logic into a separate callable function
* [x] Add basic docstrings to document all functions
* [x] Fix code style per PEP 8
* [x] Fix other minor code quality issues