### PR TITLE
Override Apache-2.0 to remove gpl-2-compatible tag

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -95,6 +95,7 @@ TAG_OVERRIDES = {
     'GNUGPLv3': {'libre', 'gpl-3-compatible'},
     'GPLv2': {'libre', 'gpl-2-compatible'},
     'LGPLv3': {'libre', 'gpl-3-compatible'},
+    'apache2': {'libre', 'gpl-3-compatible'},
 }
 
 IDENTIFIERS = {


### PR DESCRIPTION
Resolves https://github.com/wking/fsf-api/issues/25

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>