### PR TITLE
Update README and CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,18 +16,6 @@ Work along similar lines may already be in progress.
 To submit a pull request via GitHub, fork the repository, create a topic branch from `master` for your work, and send a pull request when ready.
 If you would prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by email.
 
-The extracted data is in the `gh-pages` branch.
-
-To generate a pull request for the data, clone the gh-pages branch into a separate directory:
-
-    $ git clone -b gh-pages https://github.com/spdx/fsf-api.git data
-	
-Run the pull.py script with the data directory as the parameter:
-
-	$ python ../fsf-api/pull.py data
-
-You can then create a pull request for the updated data.
-
 ## Signing Your Changes
 
 However you choose to contribute, please sign-off each of your commits to certify them under the terms of the [Developer Certificate of Origin](https://developercertificate.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,20 @@
-Issues
-------
-`fsf-api` has a [project page on GitHub](https://github.com/spdx/fsf-api) where you can [create an issue](https://github.com/spdx/fsf-api/issues/new/choose) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make. You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
+# Contributing Guide
+
+## Reporting Issues
+
+`fsf-api` has a [project page on GitHub](https://github.com/spdx/fsf-api) where you can [create an issue](https://github.com/spdx/fsf-api/issues/new/choose) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make.
+You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
 
 If you would like to work on a fix for any issue, please assign the issue to yourself prior to creating a Pull Request.
 
-Pull Requests
--------
-The `master` branch of this repository contains [the pulling script](pull.py) and associated documentation.  Please review [open pull requests](https://github.com/spdx/fsf-api/pulls) and [active branches](https://github.com/spdx/fsf-api/branches) before committing time to a substantial revision. Work along similar lines may already be in progress.
+## Submitting Pull Requests
 
-To submit a pull request via GitHub, fork the repository, create a topic branch from `master` for your work, and send a pull request when ready. If you would prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by e-mail.
+The `master` branch of this repository contains [the pulling script](pull.py) and associated documentation.
+Please review [open pull requests](https://github.com/spdx/fsf-api/pulls) and [active branches](https://github.com/spdx/fsf-api/branches) before committing time to a substantial revision.
+Work along similar lines may already be in progress.
+
+To submit a pull request via GitHub, fork the repository, create a topic branch from `master` for your work, and send a pull request when ready.
+If you would prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by email.
 
 The extracted data is in the `gh-pages` branch.
 
@@ -20,10 +26,11 @@ Run the pull.py script with the data directory as the parameter:
 
 	$ python ../fsf-api/pull.py data
 
-You can then create a pull request for the updated data
+You can then create a pull request for the updated data.
 
-Licensing
----------
-However you choose to contribute, please sign-off in each of your commits that you license your contributions under the terms of [the Developer Certificate of Origin](https://developercertificate.org/). Git has utilities for signing off on commits: `git commit -s` signs a current commit, and `git rebase --signoff <revision-range>` retroactively signs a range of past commits.
+## Signing Your Changes
+
+However you choose to contribute, please sign-off each of your commits to certify them under the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
+Git has built-in support for signing off: `git commit -s` signs a current commit, and `git rebase --signoff <revision-range>` retroactively signs a range of past commits.
 
 The content of the `master` branch is available under [the MIT license](LICENSE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,29 @@
-The `master` branch of this repository contains [the pulling script](pull.py) and associated documentation.
+Issues
+------
+`fsf-api` has a [project page on GitHub](https://github.com/spdx/fsf-api) where you can [create an issue](https://github.com/spdx/fsf-api/issues/new/choose) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make. You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
+
+If you would like to work on a fix for any issue, please assign the issue to yourself prior to creating a Pull Request.
+
+Pull Requests
+-------
+The `master` branch of this repository contains [the pulling script](pull.py) and associated documentation.  Please review [open pull requests](https://github.com/spdx/fsf-api/pulls) and [active branches](https://github.com/spdx/fsf-api/branches) before committing time to a substantial revision. Work along similar lines may already be in progress.
+
+To submit a pull request via GitHub, fork the repository, create a topic branch from `master` for your work, and send a pull request when ready. If you would prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by e-mail.
+
 The extracted data is in the `gh-pages` branch.
-To contribute to this project, clone it:
 
-    $ git clone https://github.com/wking/fsf-api.git
+To generate a pull request for the data, clone the gh-pages branch into a separate directory:
 
-And clone another directory to hold `gh-pages`:
+    $ git clone -b gh-pages https://github.com/spdx/fsf-api.git data
+	
+Run the pull.py script with the data directory as the parameter:
 
-    $ cd fsf-api
-    $ git clone -b gh-pages https://github.com/wking/fsf-api.git data
+	$ python ../fsf-api/pull.py data
 
-After committing a change to `pull.py` in `fsf-api`, change into the data directory, rebuild, and publish:
+You can then create a pull request for the updated data
 
-    $ cd data
-    $ make commit
-    $ git push origin gh-pages
+Licensing
+---------
+However you choose to contribute, please sign-off in each of your commits that you license your contributions under the terms of [the Developer Certificate of Origin](https://developercertificate.org/). Git has utilities for signing off on commits: `git commit -s` signs a current commit, and `git rebase --signoff <revision-range>` retroactively signs a range of past commits.
 
 The content of the `master` branch is available under [the MIT license](LICENSE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,4 @@ If you would prefer to send a patch or grant access to pull from your own Git re
 However you choose to contribute, please sign-off each of your commits to certify them under the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
 Git has built-in support for signing off: `git commit -s` signs a current commit, and `git rebase --signoff <revision-range>` retroactively signs a range of past commits.
 
-The content of the `master` branch is available under [the MIT license](LICENSE.md).
+The content of the `master` branch is available under [the MIT (Expat) license](LICENSE.md).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2017 fsf-api contributors
+Copyright (c) 2021 fsf-api contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -10,26 +10,26 @@ Ideally we'll hand this repository over to the FSF once they're ready to maintai
 ## Endpoints
 
 <a name="licenses.json"></a>
-You can pull an array of identifiers from [https://wking.github.io/fsf-api/licenses.json](https://wking.github.io/fsf-api/licenses.json).
+You can pull an array of identifiers from [https://spdx.github.io/fsf-api/licenses.json](https://spdx.github.io/fsf-api/licenses.json).
 
 <a name="licenses-full.json"></a>
-You can pull an object with all the license data [https://wking.github.io/fsf-api/licenses-full.json](https://wking.github.io/fsf-api/licenses-full.json).
+You can pull an object with all the license data [https://spdx.github.io/fsf-api/licenses-full.json](https://spdx.github.io/fsf-api/licenses-full.json).
 
 You can pull an individual license from a few places:
 
 * <a name="by-fsf-id"></a>
     Using their FSF ID:
 
-        https://wking.github.io/fsf-api/{id}.json
+        https://spdx.github.io/fsf-api/{id}.json
 
-    For example [https://wking.github.io/fsf-api/Expat.json](https://wking.github.io/fsf-api/Expat.json).
+    For example [https://spdx.github.io/fsf-api/Expat.json](https://spdx.github.io/fsf-api/Expat.json).
 
 * <a name="by-non-fsf-id"></a>
     Using a non-FSF ID, according to the mapping between other scheme and the FSF scheme asserted by this API:
 
-        https://wking.github.io/fsf-api/{scheme}/{id}.json
+        https://spdx.github.io/fsf-api/{scheme}/{id}.json
 
-    For example [https://wking.github.io/fsf-api/spdx/MIT.json](https://wking.github.io/fsf-api/spdx/MIT.json).
+    For example [https://spdx.github.io/fsf-api/spdx/MIT.json](https://spdx.github.io/fsf-api/spdx/MIT.json).
     This API currently [attempts](#caveats) to maintain the following mappings:
 
     * `spdx`, using [the SPDX identifiers][spdx-list].
@@ -81,6 +81,9 @@ There are currently some hacks in [the pulling script](pull.py):
     For example, the FSF currently only distinguishes between `gpl-2-compatible` and `gpl-3-compatible` in text, so licenses that are only compatible with one or the other need tag overrides.
 
 Until these hacks are addressed, license IDs and the `tags` and `identifiers` fields should be taken with a grain of salt.
+
+## Credits
+The original implementation of the fsf-api was provided by @wking.  This repository is now being maintained by the SPDX community.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ There are currently some hacks in [the pulling script](pull.py):
 Until these hacks are addressed, license IDs and the `tags` and `identifiers` fields should be taken with a grain of salt.
 
 ## Credits
-The original implementation of the fsf-api was provided by @wking.  This repository is now being maintained by the SPDX community.
+
+The original implementation of the fsf-api was provided by @wking.
+This repository is now being maintained by the SPDX community.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The original implementation of the fsf-api was provided by @wking.  This reposit
 
 [automated-matching]: https://github.com/spdx/license-list-XML/issues/418
 [fsf-afl]: https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense
-[fsf-api]: https://lists.spdx.org/pipermail/spdx-legal/2017-October/002281.html
+[fsf-api]: https://lists.spdx.org/g/Spdx-legal/topic/providing_access_to_fsf/22080894
 [fsf-freebsd-fdl]: https://www.gnu.org/licenses/license-list.html#FreeBSDDL
 [fsf-freebsd-gpl]: https://www.gnu.org/licenses/license-list.html#FreeBSD
 [fsf-gplv3]: https://www.gnu.org/licenses/license-list.html#GNUGPLv3


### PR DESCRIPTION
Update the documentation with the following changes:
- Change links from the wking repository to the spdx repository
- Update the (previously) broken link to the SPDX mailing list per https://github.com/wking/fsf-api/pull/23
- Add issues and pull request details to CONTRIBUTING
- Add sign-off requirement and DCO reference to CONTRIBUTING
- Change the documentation for how to generate the gh-pages (note: the Makefile was removed in commit https://github.com/spdx/fsf-api/commit/d455634441a9ce3db9c589f70e9a88938d018a02)
- Added credits to document @wking's initial contributions