### PR TITLE
Fix version tag of GitHub Pages deploy action to resolve #11

### DIFF
--- a/.github/workflows/deploy-ghpages.yaml
+++ b/.github/workflows/deploy-ghpages.yaml
@@ -25,7 +25,7 @@ jobs:
       shell: bash
       run: ./ci/build.sh
     - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@4.1.5
       with:
         BRANCH: gh-pages    # The branch the action should deploy to
         FOLDER: ./fsf-api-build-output    # The folder the action should deploy


### PR DESCRIPTION
Reverting back to using the full version rather than the floating one, as it evidently isn't supported for this action after all (despite seemingly being present in the repo).

Fix #11 