### PR TITLE
Fix detection for AGPL-1.0 variants

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -99,7 +99,7 @@ TAG_OVERRIDES = {
 }
 
 IDENTIFIERS = {
-    'AGPLv1.0': {'spdx': ['AGPL-1.0']},
+    'AGPLv1.0': {'spdx': ['AGPL-1.0-or-later', 'AGPL-1.0-only', 'AGPL-1.0']},
     'AGPLv3.0': {'spdx': ['AGPL-3.0-or-later', 'AGPL-3.0-only', 'AGPL-3.0']},
     'AcademicFreeLicense1.1': {'spdx': ['AFL-1.1']},
     'AcademicFreeLicense1.2': {'spdx': ['AFL-1.2']},


### PR DESCRIPTION
The identifier `AGPL-1.0` was deprecated in the 3.1 release of the SPDX License List; this commit fixes the detection code to associate 'AGPLv1.0' to both the `AGPL-1.0-only` and `AGPL-1.0-or-later` identifiers.

Signed-off-by: Sebastian Crane <seabass-labrax@gmx.com>